### PR TITLE
Characters that cannot be used in files

### DIFF
--- a/download.rb
+++ b/download.rb
@@ -47,7 +47,19 @@ loop do
       puts "Download #{download_filename}"
 
       begin
-        File.open("#{DOWNLOAD_DIR}/#{download_filename.gsub('/', '_')}", 'wb') do |output|
+        # Characters that cannot be used in files
+        # \ / : * ? " < > | 
+        File.open("#{DOWNLOAD_DIR}/#{download_filename
+        .gsub("\\", "_")
+        .gsub("/", "_")
+        .gsub(":", "_")
+        .gsub("\*", "_")
+        .gsub("\?", "_")
+        .gsub("\"", "_")
+        .gsub("<", "_")
+        .gsub(">", "_")
+        .gsub("|", "_")
+        }", 'wb') do |output|
           output.write(URI.parse(file.url_private_download).open(AUTHORIZATION).read)
         end
       rescue StandardError => e

--- a/download.rb
+++ b/download.rb
@@ -6,7 +6,7 @@ require 'open-uri'
 Dotenv.load
 ACCESS_TOKEN = ENV['ACCESS_TOKEN']
 DOWNLOAD_DIR = (ENV['DOWNLOAD_DIR'] || 'download').freeze
-WAIT_SECONDS_ON_ERROR = ENV['WAIT_SECONDS_ON_ERROR'] || 10
+WAIT_SECONDS_ON_ERROR = ENV['WAIT_SECONDS_ON_ERROR'].to_i || 10
 AUTHORIZATION = { 'Authorization' => "Bearer #{ACCESS_TOKEN}" }.freeze
 COUNT = 1000
 client = Slack::Web::Client.new token: ACCESS_TOKEN


### PR DESCRIPTION
こんにちは、
Slackの添付ファイルを一括ダウンロードで今のSlackのトークンに対応しているコードがなかなか見つからず。
こちらを使わせていただきました、とても助かりましたありがとうございます。

使わせていただいて気になったことがありましたので、プルリクさせていただきました。

7c3459e
Slackの添付ファイルはローカルからアップロードしたもののほか、スニペットで登録したファイルも添付ファイルとして扱われているようです。
![image](https://user-images.githubusercontent.com/1531196/122238380-0b804180-cefb-11eb-8930-89d8c2a03e63.png)
これが問題でダウンロードしたファイルが上手く作られず、エラーで停まってしまうことがありました。
この件に関しては、ファイル名に使えない文字を置換して対応しています。

e4e220e
次にエラーキャッチのところですが、.envでWAIT_SECONDS_ON_ERRORを設定していた場合、タイプエラーになっているようです。数値型に変換する処理を足しました。

rubyは殆ど触ったことがなく、拙いコードですが以上です。

よろしくお願いいたします
